### PR TITLE
Remove caddy-auth-jwt from xcaddy build

### DIFF
--- a/raw/Dockerfile
+++ b/raw/Dockerfile
@@ -1,7 +1,6 @@
 FROM caddy:2.4.2-builder AS builder
 
 RUN xcaddy build \
-    --with github.com/greenpau/caddy-auth-jwt@v1.2.7 \
     --with github.com/greenpau/caddy-auth-portal \
     --with github.com/caddy-dns/cloudflare
 


### PR DESCRIPTION
It's an depdendency of caddy-auth-portal and shouldn't be needed.